### PR TITLE
Fixing unicode decode error for SCSS files.

### DIFF
--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -369,7 +369,17 @@ hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
 hooks.Filters.ENV_PATTERNS_INCLUDE.add_items(
     [
         # Include files from "partials" folders
-        r"(.*/)?partials(/.*)?$",
+        r"caregiver/lms/static/sass/partials/lms/theme/",
+        r"choose-aerospace/lms/static/sass/partials/lms/theme/",
+        r"educateworkforce/lms/static/sass/partials/lms/theme/",
+        r"harford-community-college/lms/static/sass/partials/lms/theme/",
+        r"indigo/lms/static/sass/partials/lms/theme/",
+        r"meep/lms/static/sass/partials/lms/theme/",
+        r"ncatech/lms/static/sass/partials/lms/theme/",
+        r"photonics/lms/static/sass/partials/lms/theme/",
+        r"spartanburg/lms/static/sass/partials/lms/theme/",
+        r"thin-school/lms/static/sass/partials/lms/theme/",
+        r"trustworks-cymanii/lms/static/sass/partials/lms/theme/",
     ]
 )
 


### PR DESCRIPTION
Jinja2 error
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf6 in position 9: invalid start byte

Stack trace.
```
(venv) ubuntu@ip-172-16-26-247:~/.local/share/tutor-plugins/tutor-indigo-14.0.0/tutorindigo$ tutor config save
Configuration saved to /home/ubuntu/.local/share/tutor/config.yml
Configuration saved to /home/ubuntu/.local/share/tutor/config.yml
^[[AError loading template apps/openedx/settings/partials/__pycache__/common_test.cpython-310.pyc
Traceback (most recent call last):
  File "/home/ubuntu/venv/bin/tutor", line 8, in <module>
    sys.exit(main())
  File "/home/ubuntu/venv/lib/python3.10/site-packages/tutor/commands/cli.py", line 24, in main
    cli()  # pylint: disable=no-value-for-parameter
  File "/home/ubuntu/venv/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ubuntu/venv/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ubuntu/venv/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/click/decorators.py", line 38, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/tutor/commands/config.py", line 64, in save
    env.save(context.root, config)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/tutor/env.py", line 262, in save
    save_all_from(src, os.path.join(root_env, dst), config)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/tutor/env.py", line 280, in save_all_from
    renderer.render_all_to(dst, prefix.replace(os.sep, "/"))
  File "/home/ubuntu/venv/lib/python3.10/site-packages/tutor/env.py", line 205, in render_all_to
    rendered = self.render_template(template_name)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/tutor/env.py", line 186, in render_template
    template = self.environment.get_template(template_name)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/jinja2/environment.py", line 1010, in get_template
    return self._load_template(name, globals)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/jinja2/environment.py", line 969, in _load_template
    template = self.loader.load(self, name, self.make_globals(globals))
  File "/home/ubuntu/venv/lib/python3.10/site-packages/jinja2/loaders.py", line 126, in load
    source, filename, uptodate = self.get_source(environment, name)
  File "/home/ubuntu/venv/lib/python3.10/site-packages/jinja2/loaders.py", line 204, in get_source
    contents = f.read().decode(self.encoding)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf6 in position 9: invalid start byte
```