### PR TITLE
Merge in changes for `SESSION_COOKIE_DOMAIN` and `Caddy` configuration for all subsites for production Tutor local install.

### DIFF
--- a/tutorindigo/patches/caddyfile
+++ b/tutorindigo/patches/caddyfile
@@ -1,0 +1,200 @@
+
+# Caregiver
+{{ CAREGIVER_LMS_HOST }}{$default_site_port} {
+    @favicon_matcher {
+        path_regexp ^/favicon.ico$
+    }
+    rewrite @favicon_matcher /theming/asset/images/favicon.ico
+
+    # Limit profile image upload size
+    request_body /api/profile_images/*/*/upload {
+        max_size 1MB
+    }
+    request_body {
+        max_size 4MB
+    }
+
+    import proxy "lms:8000"
+
+    {{ patch("caddyfile-lms")|indent(4) }}
+}
+
+# Choose Aerospace
+{{ CHOOSE_AEROSPACE_LMS_HOST }}{$default_site_port} {
+    @favicon_matcher {
+        path_regexp ^/favicon.ico$
+    }
+    rewrite @favicon_matcher /theming/asset/images/favicon.ico
+
+    # Limit profile image upload size
+    request_body /api/profile_images/*/*/upload {
+        max_size 1MB
+    }
+    request_body {
+        max_size 4MB
+    }
+
+    import proxy "lms:8000"
+
+    {{ patch("caddyfile-lms")|indent(4) }}
+}
+
+# EducateWorkforce (this really is not needed because we define this a default LMS_HOST)
+#{{ EDUCATEWORKFORCE_LMS_HOST }}{$default_site_port} {
+#    @favicon_matcher {
+#        path_regexp ^/favicon.ico$
+#    }
+#    rewrite @favicon_matcher /theming/asset/images/favicon.ico
+
+    # Limit profile image upload size
+#    request_body /api/profile_images/*/*/upload {
+#        max_size 1MB
+#    }
+#    request_body {
+#        max_size 4MB
+#    }
+
+#    import proxy "lms:8000"
+
+#    {{ patch("caddyfile-lms")|indent(4) }}
+#}
+
+# Harford Community College
+{{ HARFORD_COMMUNITY_COLLEGE_LMS_HOST }}{$default_site_port} {
+    @favicon_matcher {
+        path_regexp ^/favicon.ico$
+    }
+    rewrite @favicon_matcher /theming/asset/images/favicon.ico
+
+    # Limit profile image upload size
+    request_body /api/profile_images/*/*/upload {
+        max_size 1MB
+    }
+    request_body {
+        max_size 4MB
+    }
+
+    import proxy "lms:8000"
+
+    {{ patch("caddyfile-lms")|indent(4) }}
+}
+
+# MEEP
+{{ MEEP_LMS_HOST }}{$default_site_port} {
+    @favicon_matcher {
+        path_regexp ^/favicon.ico$
+    }
+    rewrite @favicon_matcher /theming/asset/images/favicon.ico
+
+    # Limit profile image upload size
+    request_body /api/profile_images/*/*/upload {
+        max_size 1MB
+    }
+    request_body {
+        max_size 4MB
+    }
+
+    import proxy "lms:8000"
+
+    {{ patch("caddyfile-lms")|indent(4) }}
+}
+
+# NCATECH
+{{ NCATECH_LMS_HOST }}{$default_site_port} {
+    @favicon_matcher {
+        path_regexp ^/favicon.ico$
+    }
+    rewrite @favicon_matcher /theming/asset/images/favicon.ico
+
+    # Limit profile image upload size
+    request_body /api/profile_images/*/*/upload {
+        max_size 1MB
+    }
+    request_body {
+        max_size 4MB
+    }
+
+    import proxy "lms:8000"
+
+    {{ patch("caddyfile-lms")|indent(4) }}
+}
+
+# MIT – AIM Photonics
+{{ PHOTONICS_LMS_HOST }}{$default_site_port} {
+    @favicon_matcher {
+        path_regexp ^/favicon.ico$
+    }
+    rewrite @favicon_matcher /theming/asset/images/favicon.ico
+
+    # Limit profile image upload size
+    request_body /api/profile_images/*/*/upload {
+        max_size 1MB
+    }
+    request_body {
+        max_size 4MB
+    }
+
+    import proxy "lms:8000"
+
+    {{ patch("caddyfile-lms")|indent(4) }}
+}
+
+# SPARTANBURG
+{{ SPARTANBURG_LMS_HOST }}{$default_site_port} {
+    @favicon_matcher {
+        path_regexp ^/favicon.ico$
+    }
+    rewrite @favicon_matcher /theming/asset/images/favicon.ico
+
+    # Limit profile image upload size
+    request_body /api/profile_images/*/*/upload {
+        max_size 1MB
+    }
+    request_body {
+        max_size 4MB
+    }
+
+    import proxy "lms:8000"
+
+    {{ patch("caddyfile-lms")|indent(4) }}
+}
+
+# THIN_SCHOOL
+{{ THIN_SCHOOL_LMS_HOST }}{$default_site_port} {
+    @favicon_matcher {
+        path_regexp ^/favicon.ico$
+    }
+    rewrite @favicon_matcher /theming/asset/images/favicon.ico
+
+    # Limit profile image upload size
+    request_body /api/profile_images/*/*/upload {
+        max_size 1MB
+    }
+    request_body {
+        max_size 4MB
+    }
+
+    import proxy "lms:8000"
+
+    {{ patch("caddyfile-lms")|indent(4) }}
+}
+
+# TRUSTWORKS_CYMANII
+{{ TRUSTWORKS_CYMANII_LMS_HOST }}{$default_site_port} {
+    @favicon_matcher {
+        path_regexp ^/favicon.ico$
+    }
+    rewrite @favicon_matcher /theming/asset/images/favicon.ico
+
+    # Limit profile image upload size
+    request_body /api/profile_images/*/*/upload {
+        max_size 1MB
+    }
+    request_body {
+        max_size 4MB
+    }
+
+    import proxy "lms:8000"
+
+    {{ patch("caddyfile-lms")|indent(4) }}
+}

--- a/tutorindigo/patches/openedx-lms-production-settings
+++ b/tutorindigo/patches/openedx-lms-production-settings
@@ -1,0 +1,41 @@
+
+# Cargiver
+if "{% if ENABLE_HTTPS %}{{ CAREGIVER_LMS_HOST }}{% else %}{{ CAREGIVER_LMS_HOST }}:8000{% endif %}" not in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.append("{% if ENABLE_HTTPS %}{{ CAREGIVER_LMS_HOST }}{% else %}{{ CAREGIVER_LMS_HOST }}:8000{% endif %}")
+
+# Choose Aerospace
+if "{% if ENABLE_HTTPS %}{{ CHOOSE_AEROSPACE_LMS_HOST }}{% else %}{{ CHOOSE_AEROSPACE_LMS_HOST }}:8000{% endif %}" not in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.append("{% if ENABLE_HTTPS %}{{ CHOOSE_AEROSPACE_LMS_HOST }}{% else %}{{ CHOOSE_AEROSPACE_LMS_HOST }}:8000{% endif %}")
+
+# EducateWorkforce (this really is not needed because we define this a default LMS_HOST)
+# if "{% if ENABLE_HTTPS %}{{ EDUCATEWORKFORCE_LMS_HOST }}{% else %}{{ EDUCATEWORKFORCE_LMS_HOST }}:8000{% endif %}" not in ALLOWED_HOSTS:
+#     ALLOWED_HOSTS.append("{% if ENABLE_HTTPS %}{{ EDUCATEWORKFORCE_LMS_HOST }}{% else %}{{ EDUCATEWORKFORCE_LMS_HOST }}:8000{% endif %}")
+
+# Harford Community College
+if "{% if ENABLE_HTTPS %}{{ HARFORD_COMMUNITY_COLLEGE_LMS_HOST }}{% else %}{{ HARFORD_COMMUNITY_COLLEGE_LMS_HOST }}:8000{% endif %}" not in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.append("{% if ENABLE_HTTPS %}{{ HARFORD_COMMUNITY_COLLEGE_LMS_HOST }}{% else %}{{ HARFORD_COMMUNITY_COLLEGE_LMS_HOST }}:8000{% endif %}")
+
+# MEEP
+if "{% if ENABLE_HTTPS %}{{ MEEP_LMS_HOST }}{% else %}{{ MEEP_LMS_HOST }}:8000{% endif %}" not in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.append("{% if ENABLE_HTTPS %}{{ MEEP_LMS_HOST }}{% else %}{{ MEEP_LMS_HOST }}:8000{% endif %}")
+
+# NCATECH
+if "{% if ENABLE_HTTPS %}{{ NCATECH_LMS_HOST }}{% else %}{{ NCATECH_LMS_HOST }}:8000{% endif %}" not in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.append("{% if ENABLE_HTTPS %}{{ NCATECH_LMS_HOST }}{% else %}{{ NCATECH_LMS_HOST }}:8000{% endif %}")
+
+# MIT – AIM Photonics
+if "{% if ENABLE_HTTPS %}{{ PHOTONICS_LMS_HOST }}{% else %}{{ PHOTONICS_LMS_HOST }}:8000{% endif %}" not in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.append("{% if ENABLE_HTTPS %}{{ PHOTONICS_LMS_HOST }}{% else %}{{ PHOTONICS_LMS_HOST }}:8000{% endif %}")
+
+# SPARTANBURG
+if "{% if ENABLE_HTTPS %}{{ SPARTANBURG_LMS_HOST }}{% else %}{{ SPARTANBURG_LMS_HOST }}:8000{% endif %}" not in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.append("{% if ENABLE_HTTPS %}{{ SPARTANBURG_LMS_HOST }}{% else %}{{ SPARTANBURG_LMS_HOST }}:8000{% endif %}")
+
+# THIN_SCHOOL
+if "{% if ENABLE_HTTPS %}{{ THIN_SCHOOL_LMS_HOST }}{% else %}{{ THIN_SCHOOL_LMS_HOST }}:8000{% endif %}" not in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.append("{% if ENABLE_HTTPS %}{{ THIN_SCHOOL_LMS_HOST }}{% else %}{{ THIN_SCHOOL_LMS_HOST }}:8000{% endif %}")
+
+# TRUSTWORKS_CYMANII
+if "{% if ENABLE_HTTPS %}{{ TRUSTWORKS_CYMANII_LMS_HOST }}{% else %}{{ TRUSTWORKS_CYMANII_LMS_HOST }}:8000{% endif %}" not in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.append("{% if ENABLE_HTTPS %}{{ TRUSTWORKS_CYMANII_LMS_HOST }}{% else %}{{ TRUSTWORKS_CYMANII_LMS_HOST }}:8000{% endif %}")
+

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -73,7 +73,7 @@ config = {
             "production": {
                 "LMS_HOST": "cargiver.{{ LMS_HOST }}", # "caregiver.educateworkforce.com",  # Need to update this to new domain structure `caregiver.courses.educateworkforce.com`.
                 "CMS_HOST": EDUCATEWORKFORCE_CMS_HOST_PROD_DEFAULT,
-                # "SESSION_COOKIE_DOMAIN": "",
+                "SESSION_COOKIE_DOMAIN": "{{ EDUCATEWORKFORCE_CONFIG_SESSION_COOKIE_DOMAIN }}",
                 # "BADGR_ISSUER_SLUG": "",
                 # "MKG_ROOT_URL": "",
             },
@@ -100,7 +100,7 @@ config = {
             "production": {
                 "LMS_HOST": "chooseaerospace.{{ LMS_HOST }}", # "courses.chooseaerospace.org",
                 "CMS_HOST": EDUCATEWORKFORCE_CMS_HOST_PROD_DEFAULT,
-                "SESSION_COOKIE_DOMAIN": "courses.chooseaerospace.org",
+                "SESSION_COOKIE_DOMAIN": "{{ EDUCATEWORKFORCE_CONFIG_SESSION_COOKIE_DOMAIN }}", # "courses.chooseaerospace.org"
                 "BADGR_ISSUER_SLUG": "3HNkqeHmRhe3-IEvYYNmcg",
                 "MKG_ROOT_URL": "learn.chooseaerospace.org",
             },
@@ -127,7 +127,7 @@ config = {
             "production": {
                 "LMS_HOST": EDUCATEWORKFORCE_LMS_HOST_PROD_DEFAULT,
                 "CMS_HOST": EDUCATEWORKFORCE_CMS_HOST_PROD_DEFAULT,
-                # "SESSION_COOKIE_DOMAIN": "",
+                "SESSION_COOKIE_DOMAIN": "{{ EDUCATEWORKFORCE_CONFIG_SESSION_COOKIE_DOMAIN }}",
                 "BADGR_ISSUER_SLUG": "XPPH2eGlT0KhekfWpCAWyA",
                 "MKG_ROOT_URL": "educateworkforce.com",
             },
@@ -154,7 +154,7 @@ config = {
             "production": {
                 "LMS_HOST": "harford.{{ LMS_HOST }}", # "harford.courses.educateworkforce.com",
                 "CMS_HOST": EDUCATEWORKFORCE_CMS_HOST_PROD_DEFAULT,
-                # "SESSION_COOKIE_DOMAIN": "",
+                "SESSION_COOKIE_DOMAIN": "{{ EDUCATEWORKFORCE_CONFIG_SESSION_COOKIE_DOMAIN }}",
                 "BADGR_ISSUER_SLUG": "44bnWQE5TiSI7opBUIqyDA",
                 "MKG_ROOT_URL": "harford.educateworkforce.com",
             },
@@ -181,7 +181,7 @@ config = {
             "production": {
                 "LMS_HOST": "meep.{{ LMS_HOST }}", # "courses.meep.educateworkforce.com",  # Need to update this to new domain structure `meep.courses.educateworkforce.com`.
                 "CMS_HOST": EDUCATEWORKFORCE_CMS_HOST_PROD_DEFAULT,
-                # "SESSION_COOKIE_DOMAIN": "",
+                "SESSION_COOKIE_DOMAIN": "{{ EDUCATEWORKFORCE_CONFIG_SESSION_COOKIE_DOMAIN }}",
                 "BADGR_ISSUER_SLUG": "X_gnRW0hQ7G1ycy9e_8P2w",
                 "MKG_ROOT_URL": "meep.educateworkforce.com",
             },
@@ -208,7 +208,7 @@ config = {
             "production": {
                 "LMS_HOST": "ncatech.{{ LMS_HOST }}", # "ncatech.courses.educateworkforce.com",
                 "CMS_HOST": EDUCATEWORKFORCE_CMS_HOST_PROD_DEFAULT,
-                # "SESSION_COOKIE_DOMAIN": "",
+                "SESSION_COOKIE_DOMAIN": "{{ EDUCATEWORKFORCE_CONFIG_SESSION_COOKIE_DOMAIN }}",
                 "BADGR_ISSUER_SLUG": "3EoLJ3pmR9KFCPVG9eLWZA",
                 "MKG_ROOT_URL": "ncatech.educateworkforce.com",
             },
@@ -235,7 +235,7 @@ config = {
             "production": {
                 "LMS_HOST": "photonics.{{ LMS_HOST }}", # "photonics.courses.educateworkforce.com",
                 "CMS_HOST": EDUCATEWORKFORCE_CMS_HOST_PROD_DEFAULT,
-                # "SESSION_COOKIE_DOMAIN": "",
+                "SESSION_COOKIE_DOMAIN": "{{ EDUCATEWORKFORCE_CONFIG_SESSION_COOKIE_DOMAIN }}",
                 "BADGR_ISSUER_SLUG": "33j37WiUSV-lPUUtht5Pvw",
                 "MKG_ROOT_URL": "photonics.educateworkforce.com",
             },
@@ -262,7 +262,7 @@ config = {
             "production": {
                 "LMS_HOST": "spartanburg.{{ LMS_HOST }}", # "spartanburg.courses.educateworkforce.com",
                 "CMS_HOST": EDUCATEWORKFORCE_CMS_HOST_PROD_DEFAULT,
-                # "SESSION_COOKIE_DOMAIN": "",
+                "SESSION_COOKIE_DOMAIN": "{{ EDUCATEWORKFORCE_CONFIG_SESSION_COOKIE_DOMAIN }}",
                 "BADGR_ISSUER_SLUG": "KJ2ni7CaRCe5eWxxj-nUcw",
                 "MKG_ROOT_URL": "spartanburg.educateworkforce.com",
             },
@@ -289,7 +289,7 @@ config = {
             "production": {
                 "LMS_HOST": "thin-school.{{ LMS_HOST }}", # "ts.educateworkforce.com",  # Need to update this to new domain structure `ts.courses.educateworkforce.com`.
                 "CMS_HOST": EDUCATEWORKFORCE_CMS_HOST_PROD_DEFAULT,
-                # "SESSION_COOKIE_DOMAIN": "",
+                "SESSION_COOKIE_DOMAIN": "{{ EDUCATEWORKFORCE_CONFIG_SESSION_COOKIE_DOMAIN }}",
                 # "BADGR_ISSUER_SLUG": "",
                 # "MKG_ROOT_URL": "",
             },
@@ -316,7 +316,7 @@ config = {
             "production": {
                 "LMS_HOST": "trustworks-cymanii.{{ LMS_HOST }}", # "learn.trustworks.cymanii.org",
                 "CMS_HOST": EDUCATEWORKFORCE_CMS_HOST_PROD_DEFAULT,
-                "SESSION_COOKIE_DOMAIN": "learn.trustworks.cymanii.org",
+                "SESSION_COOKIE_DOMAIN": "{{ EDUCATEWORKFORCE_CONFIG_SESSION_COOKIE_DOMAIN }}", # "learn.trustworks.cymanii.org"
                 "BADGR_ISSUER_SLUG": "SjuK7cxvS-eCi8h27e1hpQ",
                 "MKG_ROOT_URL": "trustworks.cymanii.org",
             },


### PR DESCRIPTION
**`SESSION_COOKIE_DOMAIN` Changes** 
Make the SESSION_COOKIE_DOMAIN same across all subsites so the learner doesn't have to relogin.

May need to revisit this for two of our subsites (Choose Aerospace and Trustworks) because they have different base domains than the rest.

**Caddy support for tutor local install for all subsites**
Added in Caddy support for these subsites to resolve with SSL and direct to internal LMS app.