### PR TITLE
Add `Clemson IdP` to the `CORS_ORIGIN_WHITELIST`.

### DIFF
--- a/tutorindigo/patches/openedx-lms-production-settings
+++ b/tutorindigo/patches/openedx-lms-production-settings
@@ -1,4 +1,8 @@
 
+# Third Party Auth (Clemson IdP)
+if "https://idp.clemson.edu" not in CORS_ORIGIN_WHITELIST:
+    CORS_ORIGIN_WHITELIST.append("https://idp.clemson.edu")
+
 # Caregiver
 if "{{ CAREGIVER_LMS_HOST }}" not in ALLOWED_HOSTS:
     ALLOWED_HOSTS.append("{{ CAREGIVER_LMS_HOST }}")
@@ -74,4 +78,5 @@ if "{{ TRUSTWORKS_CYMANII_LMS_HOST }}" not in ALLOWED_HOSTS:
     ALLOWED_HOSTS.append("{{ TRUSTWORKS_CYMANII_MFE_HOST }}")
     CORS_ORIGIN_WHITELIST.append("https://{{ TRUSTWORKS_CYMANII_LMS_HOST }}")
     CORS_ORIGIN_WHITELIST.append("https://{{ TRUSTWORKS_CYMANII_MFE_HOST }}")
+    CORS_ORIGIN_WHITELIST.append("https://{{ TRUSTWORKS_CYMANII_BIGCOMMERCE_STORE }}")
 


### PR DESCRIPTION
Received the following error when trying to login with Clemson SSO on the EducateWorkforce site.
```
tutor_local-lms-1  | 2022-12-08 17:37:55,254 INFO 38 [openedx.core.djangoapps.cors_csrf.helpers] [user None] [ip 172.18.0.1] helpers.py:64 - Origin 'https://idp.clemson.edu' was not in `CORS_ORIGIN_WHITELIST`; full referer was 'https://idp.clemson.edu/' and requested host was 'courses.educateworkforce.com'; CORS_ORIGIN_ALLOW_ALL=False
```