### PR TITLE
Remove `QUALTRICS_` configuration values from Site Configuration.

### DIFF
--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -21,10 +21,6 @@ EDUCATEWORKFORCE_CMS_HOST_PROD_DEFAULT = "{{ CMS_HOST }}"
 EDUCATEWORKFORCE_SUPPORT_EMAIL = "support@educateworkforce.com"
 EDUCATEWORKFORCE_DEFAULT_FROM_EMAIL = "no-reply@educateworkforce.com"
 
-# Qualtrics Settings for `clemson.ca1`. Most surveys on EducateWorkforce use this for production, however,
-# you can override these should an organization want to use their own Qualtrics organization account (e.g. CyManII)
-EDUCATEWORKFORCE_QUALTRICS_SCORE_ID = "SC_8Joxltl97oYWdAa"
-
 ENVIRONMENT = "development"
 MKG_HOST = "localhost:8080"
 
@@ -97,8 +93,7 @@ config = {
                 ],
                 "FOOTER_LEGAL_LINKS": [
                     {"title": "Terms of Service", "url": "/tos"},
-                ],
-                "QUALTRICS_SCORE_ID": EDUCATEWORKFORCE_QUALTRICS_SCORE_ID,
+                ]
             }
         },
         "CHOOSE_AEROSPACE": {
@@ -127,7 +122,6 @@ config = {
                 "FOOTER_LEGAL_LINKS": [
                     {"title": "Terms of Service", "url": "/tos"},
                 ],
-                "QUALTRICS_SCORE_ID": EDUCATEWORKFORCE_QUALTRICS_SCORE_ID,
             }
         },
         "EDUCATEWORKFORCE": {
@@ -156,7 +150,6 @@ config = {
                 "FOOTER_LEGAL_LINKS": [
                     {"title": "Terms of Service", "url": "/tos"},
                 ],
-                "QUALTRICS_SCORE_ID": EDUCATEWORKFORCE_QUALTRICS_SCORE_ID,
             }
         },
         "HARFORD_COMMUNITY_COLLEGE": {
@@ -185,7 +178,6 @@ config = {
                 "FOOTER_LEGAL_LINKS": [
                     {"title": "Terms of Service", "url": "/tos"},
                 ],
-                "QUALTRICS_SCORE_ID": EDUCATEWORKFORCE_QUALTRICS_SCORE_ID,
             }
         },
         "MEEP": {
@@ -214,7 +206,6 @@ config = {
                 "FOOTER_LEGAL_LINKS": [
                     {"title": "Terms of Service", "url": "/tos"},
                 ],
-                "QUALTRICS_SCORE_ID": EDUCATEWORKFORCE_QUALTRICS_SCORE_ID,
             }
         },
         "NCATECH": {
@@ -243,7 +234,6 @@ config = {
                 "FOOTER_LEGAL_LINKS": [
                     {"title": "Terms of Service", "url": "/tos"},
                 ],
-                "QUALTRICS_SCORE_ID": EDUCATEWORKFORCE_QUALTRICS_SCORE_ID,
             }
         },
         "PHOTONICS": {
@@ -272,7 +262,6 @@ config = {
                 "FOOTER_LEGAL_LINKS": [
                     {"title": "Terms of Service", "url": "/tos"},
                 ],
-                "QUALTRICS_SCORE_ID": EDUCATEWORKFORCE_QUALTRICS_SCORE_ID,
             }
         },
         "REVVED": {
@@ -301,7 +290,6 @@ config = {
                 "FOOTER_LEGAL_LINKS": [
                     {"title": "Terms of Service", "url": "/tos"},
                 ],
-                "QUALTRICS_SCORE_ID": EDUCATEWORKFORCE_QUALTRICS_SCORE_ID,
             }
         },
         "SPARTANBURG": {
@@ -330,7 +318,6 @@ config = {
                 "FOOTER_LEGAL_LINKS": [
                     {"title": "Terms of Service", "url": "/tos"},
                 ],
-                "QUALTRICS_SCORE_ID": EDUCATEWORKFORCE_QUALTRICS_SCORE_ID,
             }
         },
         "THIN_SCHOOL": {
@@ -359,7 +346,6 @@ config = {
                 "FOOTER_LEGAL_LINKS": [
                     {"title": "Terms of Service", "url": "/tos"},
                 ],
-                "QUALTRICS_SCORE_ID": EDUCATEWORKFORCE_QUALTRICS_SCORE_ID,
             }
         },
         "TRUSTWORKS_CYMANII": {
@@ -390,7 +376,6 @@ config = {
                 "FOOTER_LEGAL_LINKS": [
                     {"title": "Terms of Service", "url": "/tos"},
                 ],
-                "QUALTRICS_SCORE_ID": EDUCATEWORKFORCE_QUALTRICS_SCORE_ID,
             }
         },
         "WATER_DROPS": {
@@ -419,7 +404,6 @@ config = {
                 "FOOTER_LEGAL_LINKS": [
                     {"title": "Terms of Service", "url": "/tos"},
                 ],
-                "QUALTRICS_SCORE_ID": EDUCATEWORKFORCE_QUALTRICS_SCORE_ID,
             }
         }
     }

--- a/tutorindigo/templates/caregiver/tasks/lms/init
+++ b/tutorindigo/templates/caregiver/tasks/lms/init
@@ -121,7 +121,6 @@ do
     " --json-argument
     site-configuration set --domain=$domain PLATFORM_NAME "{{ CAREGIVER_PLATFORM_NAME }}"
     site-configuration set --domain=$domain PROFILE_MICROFRONTEND_URL "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ CAREGIVER_MFE_HOST }}/profile/u/"
-    site-configuration set --domain=$domain QUALTRICS_SCORE_ID "{{ CAREGIVER_QUALTRICS_SCORE_ID }}"
     site-configuration set --domain=$domain RESTRICT_ENROLL_BY_REG_METHOD true
 
     {% if CAREGIVER_SESSION_COOKIE_DOMAIN %}

--- a/tutorindigo/templates/choose-aerospace/tasks/lms/init
+++ b/tutorindigo/templates/choose-aerospace/tasks/lms/init
@@ -121,7 +121,6 @@ do
     " --json-argument
     site-configuration set --domain=$domain PLATFORM_NAME "{{ CHOOSE_AEROSPACE_PLATFORM_NAME }}"
     site-configuration set --domain=$domain PROFILE_MICROFRONTEND_URL "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ CHOOSE_AEROSPACE_MFE_HOST }}/profile/u/"
-    site-configuration set --domain=$domain QUALTRICS_SCORE_ID "{{ CHOOSE_AEROSPACE_QUALTRICS_SCORE_ID }}"
     site-configuration set --domain=$domain RESTRICT_ENROLL_BY_REG_METHOD true
 
     {% if CHOOSE_AEROSPACE_SESSION_COOKIE_DOMAIN %}

--- a/tutorindigo/templates/educateworkforce/tasks/lms/init
+++ b/tutorindigo/templates/educateworkforce/tasks/lms/init
@@ -121,7 +121,6 @@ do
     " --json-argument
     site-configuration set --domain=$domain PLATFORM_NAME "{{ EDUCATEWORKFORCE_PLATFORM_NAME }}"
     site-configuration set --domain=$domain PROFILE_MICROFRONTEND_URL "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ EDUCATEWORKFORCE_MFE_HOST }}/profile/u/"
-    site-configuration set --domain=$domain QUALTRICS_SCORE_ID "{{ EDUCATEWORKFORCE_QUALTRICS_SCORE_ID }}"
     site-configuration set --domain=$domain RESTRICT_ENROLL_BY_REG_METHOD true
 
     {% if EDUCATEWORKFORCE_SESSION_COOKIE_DOMAIN %}

--- a/tutorindigo/templates/harford-community-college/tasks/lms/init
+++ b/tutorindigo/templates/harford-community-college/tasks/lms/init
@@ -121,7 +121,6 @@ do
     " --json-argument
     site-configuration set --domain=$domain PLATFORM_NAME "{{ HARFORD_COMMUNITY_COLLEGE_PLATFORM_NAME }}"
     site-configuration set --domain=$domain PROFILE_MICROFRONTEND_URL "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ HARFORD_COMMUNITY_COLLEGE_MFE_HOST }}/profile/u/"
-    site-configuration set --domain=$domain QUALTRICS_SCORE_ID "{{ HARFORD_COMMUNITY_COLLEGE_QUALTRICS_SCORE_ID }}"
     site-configuration set --domain=$domain RESTRICT_ENROLL_BY_REG_METHOD true
 
     {% if HARFORD_COMMUNITY_COLLEGE_SESSION_COOKIE_DOMAIN %}

--- a/tutorindigo/templates/meep/tasks/lms/init
+++ b/tutorindigo/templates/meep/tasks/lms/init
@@ -121,7 +121,6 @@ do
     " --json-argument
     site-configuration set --domain=$domain PLATFORM_NAME "{{ MEEP_PLATFORM_NAME }}"
     site-configuration set --domain=$domain PROFILE_MICROFRONTEND_URL "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ MEEP_MFE_HOST }}/profile/u/"
-    site-configuration set --domain=$domain QUALTRICS_SCORE_ID "{{ MEEP_QUALTRICS_SCORE_ID }}"
     site-configuration set --domain=$domain RESTRICT_ENROLL_BY_REG_METHOD true
 
     {% if MEEP_SESSION_COOKIE_DOMAIN %}

--- a/tutorindigo/templates/ncatech/tasks/lms/init
+++ b/tutorindigo/templates/ncatech/tasks/lms/init
@@ -121,7 +121,6 @@ do
     " --json-argument
     site-configuration set --domain=$domain PLATFORM_NAME "{{ NCATECH_PLATFORM_NAME }}"
     site-configuration set --domain=$domain PROFILE_MICROFRONTEND_URL "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ NCATECH_MFE_HOST }}/profile/u/"
-    site-configuration set --domain=$domain QUALTRICS_SCORE_ID "{{ NCATECH_QUALTRICS_SCORE_ID }}"
     site-configuration set --domain=$domain RESTRICT_ENROLL_BY_REG_METHOD true
 
     {% if NCATECH_SESSION_COOKIE_DOMAIN %}

--- a/tutorindigo/templates/photonics/tasks/lms/init
+++ b/tutorindigo/templates/photonics/tasks/lms/init
@@ -121,7 +121,6 @@ do
     " --json-argument
     site-configuration set --domain=$domain PLATFORM_NAME "{{ PHOTONICS_PLATFORM_NAME }}"
     site-configuration set --domain=$domain PROFILE_MICROFRONTEND_URL "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ PHOTONICS_MFE_HOST }}/profile/u/"
-    site-configuration set --domain=$domain QUALTRICS_SCORE_ID "{{ PHOTONICS_QUALTRICS_SCORE_ID }}"
     site-configuration set --domain=$domain RESTRICT_ENROLL_BY_REG_METHOD true
 
     {% if PHOTONICS_SESSION_COOKIE_DOMAIN %}

--- a/tutorindigo/templates/revved/tasks/lms/init
+++ b/tutorindigo/templates/revved/tasks/lms/init
@@ -121,7 +121,6 @@ do
     " --json-argument
     site-configuration set --domain=$domain PLATFORM_NAME "{{ REVVED_PLATFORM_NAME }}"
     site-configuration set --domain=$domain PROFILE_MICROFRONTEND_URL "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ REVVED_MFE_HOST }}/profile/u/"
-    site-configuration set --domain=$domain QUALTRICS_SCORE_ID "{{ REVVED_QUALTRICS_SCORE_ID }}"
     site-configuration set --domain=$domain RESTRICT_ENROLL_BY_REG_METHOD true
 
     {% if REVVED_SESSION_COOKIE_DOMAIN %}

--- a/tutorindigo/templates/spartanburg/tasks/lms/init
+++ b/tutorindigo/templates/spartanburg/tasks/lms/init
@@ -121,7 +121,6 @@ do
     " --json-argument
     site-configuration set --domain=$domain PLATFORM_NAME "{{ SPARTANBURG_PLATFORM_NAME }}"
     site-configuration set --domain=$domain PROFILE_MICROFRONTEND_URL "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ SPARTANBURG_MFE_HOST }}/profile/u/"
-    site-configuration set --domain=$domain QUALTRICS_SCORE_ID "{{ SPARTANBURG_QUALTRICS_SCORE_ID }}"
     site-configuration set --domain=$domain RESTRICT_ENROLL_BY_REG_METHOD true
 
     {% if SPARTANBURG_SESSION_COOKIE_DOMAIN %}

--- a/tutorindigo/templates/thin-school/tasks/lms/init
+++ b/tutorindigo/templates/thin-school/tasks/lms/init
@@ -121,7 +121,6 @@ do
     " --json-argument
     site-configuration set --domain=$domain PLATFORM_NAME "{{ THIN_SCHOOL_PLATFORM_NAME }}"
     site-configuration set --domain=$domain PROFILE_MICROFRONTEND_URL "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ THIN_SCHOOL_MFE_HOST }}/profile/u/"
-    site-configuration set --domain=$domain QUALTRICS_SCORE_ID "{{ THIN_SCHOOL_QUALTRICS_SCORE_ID }}"
     site-configuration set --domain=$domain RESTRICT_ENROLL_BY_REG_METHOD true
 
     {% if THIN_SCHOOL_SESSION_COOKIE_DOMAIN %}

--- a/tutorindigo/templates/trustworks-cymanii/tasks/lms/init
+++ b/tutorindigo/templates/trustworks-cymanii/tasks/lms/init
@@ -125,7 +125,6 @@ do
     " --json-argument
     site-configuration set --domain=$domain PLATFORM_NAME "{{ TRUSTWORKS_CYMANII_PLATFORM_NAME }}"
     site-configuration set --domain=$domain PROFILE_MICROFRONTEND_URL "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ TRUSTWORKS_CYMANII_MFE_HOST }}/profile/u/"
-    site-configuration set --domain=$domain QUALTRICS_SCORE_ID "{{ TRUSTWORKS_CYMANII_QUALTRICS_SCORE_ID }}"
     site-configuration set --domain=$domain RESTRICT_ENROLL_BY_REG_METHOD true
 
     {% if TRUSTWORKS_CYMANII_SESSION_COOKIE_DOMAIN %}

--- a/tutorindigo/templates/water-drops/tasks/lms/init
+++ b/tutorindigo/templates/water-drops/tasks/lms/init
@@ -121,7 +121,6 @@ do
     " --json-argument
     site-configuration set --domain=$domain PLATFORM_NAME "{{ WATER_DROPS_PLATFORM_NAME }}"
     site-configuration set --domain=$domain PROFILE_MICROFRONTEND_URL "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ WATER_DROPS_MFE_HOST }}/profile/u/"
-    site-configuration set --domain=$domain QUALTRICS_SCORE_ID "{{ WATER_DROPS_QUALTRICS_SCORE_ID }}"
     site-configuration set --domain=$domain RESTRICT_ENROLL_BY_REG_METHOD true
 
     {% if WATER_DROPS_SESSION_COOKIE_DOMAIN %}


### PR DESCRIPTION
Because we're allowing our Qualtrics XBlocks to connect to more than one Qualtric's organization we need to ensure that the XBlock is pulling from the right configuration rather than the same Site configuration settings.