### PR TITLE
Enable CORS Origin whitelist for `Clemson` Canvas.

### DIFF
--- a/tutorindigo/patches/openedx-lms-production-settings
+++ b/tutorindigo/patches/openedx-lms-production-settings
@@ -3,6 +3,10 @@
 if "https://idp.clemson.edu" not in CORS_ORIGIN_WHITELIST:
     CORS_ORIGIN_WHITELIST.append("https://idp.clemson.edu")
 
+# Clemson Canvas
+if "https://clemson.instructure.com" not in CORS_ORIGIN_WHITELIST:
+    CORS_ORIGIN_WHITELIST.append("https://clemson.instructure.com")
+
 # Caregiver
 if "{{ CAREGIVER_LMS_HOST }}" not in ALLOWED_HOSTS:
     ALLOWED_HOSTS.append("{{ CAREGIVER_LMS_HOST }}")


### PR DESCRIPTION
We will most likely need to do this for all other Canvas, Blackboard, Moodle LMSs that are using EducateWorkforce curriculum through LTI. At the moment I'm just enable Clemson Canvas for CORS Origin whitelist.