### PR TITLE
Remove extra main LMS navigation links `How it Works`, `Schools`, and `Explore Courses` for subsites.

### DIFF
--- a/tutorindigo/templates/caregiver/lms/templates/header/navbar-authenticated.html
+++ b/tutorindigo/templates/caregiver/lms/templates/header/navbar-authenticated.html
@@ -1,0 +1,64 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+  show_explore_courses = False # configuration_helpers.get_value('COURSES_ARE_BROWSABLE', settings.FEATURES.get('COURSES_ARE_BROWSABLE'))
+  self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+
+  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+  doc_link = get_online_help_info(online_help_token)['doc_url']
+
+  if online_help_token == "instructor":
+    help_link = doc_link
+  elif support_link:
+    help_link = support_link
+  else:
+    help_link = doc_link
+%>
+
+<div class="nav-links">
+  <div class="main">
+    % if show_dashboard_tabs:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+             ${_("Courses")}
+        </a>
+      </div>
+      % if show_program_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
+             aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
+             ${_("Programs")}
+          </a>
+        </div>
+      % endif
+    % endif
+    % if show_explore_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
+             aria-current="${'page' if '/courses' in request.path else 'false'}">
+             ${_('Discover New')}
+          </a>
+      </div>
+    % endif
+  </div>
+  <div class="secondary">
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
+      </div>
+    % endif
+    <%include file="user_dropdown.html"/>
+  </div>
+</div>

--- a/tutorindigo/templates/caregiver/lms/templates/header/navbar-not-authenticated.html
+++ b/tutorindigo/templates/caregiver/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,74 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+
+<%!
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+
+from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
+%>
+<nav class="nav-links" aria-label=${_("Supplemental Links")}>
+  <div class="main">
+  % if False and mktg_site_enabled:
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+    </div>
+    % if courses_are_browsable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      </div>
+    % endif
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('SCHOOLS')}">${_("Schools")}</a>
+    </div>
+  % endif
+  % if allows_login:
+    % if False and can_discover_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="/courses">${_('Explore courses')}</a>
+      </div>
+    %endif
+  % endif
+  </div>
+  <div class="secondary">
+    <div>
+      % if allows_login:
+        % if allow_public_account_creation:
+          % if should_redirect_to_authn_mfe:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
+            </div>
+          % else:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+          % endif
+        % endif
+        % if should_redirect_to_authn_mfe:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % else:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % endif
+      % endif
+    </div>
+  </div>
+</nav>

--- a/tutorindigo/templates/choose-aerospace/lms/templates/header/navbar-authenticated.html
+++ b/tutorindigo/templates/choose-aerospace/lms/templates/header/navbar-authenticated.html
@@ -1,0 +1,64 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+  show_explore_courses = False # configuration_helpers.get_value('COURSES_ARE_BROWSABLE', settings.FEATURES.get('COURSES_ARE_BROWSABLE'))
+  self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+
+  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+  doc_link = get_online_help_info(online_help_token)['doc_url']
+
+  if online_help_token == "instructor":
+    help_link = doc_link
+  elif support_link:
+    help_link = support_link
+  else:
+    help_link = doc_link
+%>
+
+<div class="nav-links">
+  <div class="main">
+    % if show_dashboard_tabs:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+             ${_("Courses")}
+        </a>
+      </div>
+      % if show_program_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
+             aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
+             ${_("Programs")}
+          </a>
+        </div>
+      % endif
+    % endif
+    % if show_explore_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
+             aria-current="${'page' if '/courses' in request.path else 'false'}">
+             ${_('Discover New')}
+          </a>
+      </div>
+    % endif
+  </div>
+  <div class="secondary">
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
+      </div>
+    % endif
+    <%include file="user_dropdown.html"/>
+  </div>
+</div>

--- a/tutorindigo/templates/choose-aerospace/lms/templates/header/navbar-not-authenticated.html
+++ b/tutorindigo/templates/choose-aerospace/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,74 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+
+<%!
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+
+from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
+%>
+<nav class="nav-links" aria-label=${_("Supplemental Links")}>
+  <div class="main">
+  % if False and mktg_site_enabled:
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+    </div>
+    % if courses_are_browsable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      </div>
+    % endif
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('SCHOOLS')}">${_("Schools")}</a>
+    </div>
+  % endif
+  % if allows_login:
+    % if False and can_discover_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="/courses">${_('Explore courses')}</a>
+      </div>
+    %endif
+  % endif
+  </div>
+  <div class="secondary">
+    <div>
+      % if allows_login:
+        % if allow_public_account_creation:
+          % if should_redirect_to_authn_mfe:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
+            </div>
+          % else:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+          % endif
+        % endif
+        % if should_redirect_to_authn_mfe:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % else:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % endif
+      % endif
+    </div>
+  </div>
+</nav>

--- a/tutorindigo/templates/educateworkforce/lms/templates/header/navbar-authenticated.html
+++ b/tutorindigo/templates/educateworkforce/lms/templates/header/navbar-authenticated.html
@@ -1,0 +1,64 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+  show_explore_courses = configuration_helpers.get_value('COURSES_ARE_BROWSABLE', settings.FEATURES.get('COURSES_ARE_BROWSABLE'))
+  self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+
+  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+  doc_link = get_online_help_info(online_help_token)['doc_url']
+
+  if online_help_token == "instructor":
+    help_link = doc_link
+  elif support_link:
+    help_link = support_link
+  else:
+    help_link = doc_link
+%>
+
+<div class="nav-links">
+  <div class="main">
+    % if show_dashboard_tabs:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+             ${_("Courses")}
+        </a>
+      </div>
+      % if show_program_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
+             aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
+             ${_("Programs")}
+          </a>
+        </div>
+      % endif
+    % endif
+    % if show_explore_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
+             aria-current="${'page' if '/courses' in request.path else 'false'}">
+             ${_('Discover New')}
+          </a>
+      </div>
+    % endif
+  </div>
+  <div class="secondary">
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
+      </div>
+    % endif
+    <%include file="user_dropdown.html"/>
+  </div>
+</div>

--- a/tutorindigo/templates/educateworkforce/lms/templates/header/navbar-not-authenticated.html
+++ b/tutorindigo/templates/educateworkforce/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,71 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+
+<%!
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+
+from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
+%>
+<nav class="nav-links" aria-label=${_("Supplemental Links")}>
+  <div class="main">
+  % if False and mktg_site_enabled:
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+    </div>
+    % if courses_are_browsable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      </div>
+    % endif
+  % endif
+  % if allows_login:
+    % if False and can_discover_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="/courses">${_('Explore courses')}</a>
+      </div>
+    %endif
+  % endif
+  </div>
+  <div class="secondary">
+    <div>
+      % if allows_login:
+        % if allow_public_account_creation:
+          % if should_redirect_to_authn_mfe:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
+            </div>
+          % else:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+          % endif
+        % endif
+        % if should_redirect_to_authn_mfe:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % else:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % endif
+      % endif
+    </div>
+  </div>
+</nav>

--- a/tutorindigo/templates/harford-community-college/lms/templates/header/navbar-authenticated.html
+++ b/tutorindigo/templates/harford-community-college/lms/templates/header/navbar-authenticated.html
@@ -1,0 +1,64 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+  show_explore_courses = False # configuration_helpers.get_value('COURSES_ARE_BROWSABLE', settings.FEATURES.get('COURSES_ARE_BROWSABLE'))
+  self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+
+  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+  doc_link = get_online_help_info(online_help_token)['doc_url']
+
+  if online_help_token == "instructor":
+    help_link = doc_link
+  elif support_link:
+    help_link = support_link
+  else:
+    help_link = doc_link
+%>
+
+<div class="nav-links">
+  <div class="main">
+    % if show_dashboard_tabs:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+             ${_("Courses")}
+        </a>
+      </div>
+      % if show_program_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
+             aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
+             ${_("Programs")}
+          </a>
+        </div>
+      % endif
+    % endif
+    % if show_explore_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
+             aria-current="${'page' if '/courses' in request.path else 'false'}">
+             ${_('Discover New')}
+          </a>
+      </div>
+    % endif
+  </div>
+  <div class="secondary">
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
+      </div>
+    % endif
+    <%include file="user_dropdown.html"/>
+  </div>
+</div>

--- a/tutorindigo/templates/harford-community-college/lms/templates/header/navbar-not-authenticated.html
+++ b/tutorindigo/templates/harford-community-college/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,74 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+
+<%!
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+
+from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
+%>
+<nav class="nav-links" aria-label=${_("Supplemental Links")}>
+  <div class="main">
+  % if False and mktg_site_enabled:
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+    </div>
+    % if courses_are_browsable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      </div>
+    % endif
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('SCHOOLS')}">${_("Schools")}</a>
+    </div>
+  % endif
+  % if allows_login:
+    % if False and can_discover_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="/courses">${_('Explore courses')}</a>
+      </div>
+    %endif
+  % endif
+  </div>
+  <div class="secondary">
+    <div>
+      % if allows_login:
+        % if allow_public_account_creation:
+          % if should_redirect_to_authn_mfe:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
+            </div>
+          % else:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+          % endif
+        % endif
+        % if should_redirect_to_authn_mfe:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % else:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % endif
+      % endif
+    </div>
+  </div>
+</nav>

--- a/tutorindigo/templates/meep/lms/templates/header/navbar-authenticated.html
+++ b/tutorindigo/templates/meep/lms/templates/header/navbar-authenticated.html
@@ -1,0 +1,64 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+  show_explore_courses = False # configuration_helpers.get_value('COURSES_ARE_BROWSABLE', settings.FEATURES.get('COURSES_ARE_BROWSABLE'))
+  self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+
+  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+  doc_link = get_online_help_info(online_help_token)['doc_url']
+
+  if online_help_token == "instructor":
+    help_link = doc_link
+  elif support_link:
+    help_link = support_link
+  else:
+    help_link = doc_link
+%>
+
+<div class="nav-links">
+  <div class="main">
+    % if show_dashboard_tabs:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+             ${_("Courses")}
+        </a>
+      </div>
+      % if show_program_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
+             aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
+             ${_("Programs")}
+          </a>
+        </div>
+      % endif
+    % endif
+    % if show_explore_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
+             aria-current="${'page' if '/courses' in request.path else 'false'}">
+             ${_('Discover New')}
+          </a>
+      </div>
+    % endif
+  </div>
+  <div class="secondary">
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
+      </div>
+    % endif
+    <%include file="user_dropdown.html"/>
+  </div>
+</div>

--- a/tutorindigo/templates/meep/lms/templates/header/navbar-not-authenticated.html
+++ b/tutorindigo/templates/meep/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,74 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+
+<%!
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+
+from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
+%>
+<nav class="nav-links" aria-label=${_("Supplemental Links")}>
+  <div class="main">
+  % if False and mktg_site_enabled:
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+    </div>
+    % if courses_are_browsable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      </div>
+    % endif
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('SCHOOLS')}">${_("Schools")}</a>
+    </div>
+  % endif
+  % if allows_login:
+    % if False and can_discover_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="/courses">${_('Explore courses')}</a>
+      </div>
+    %endif
+  % endif
+  </div>
+  <div class="secondary">
+    <div>
+      % if allows_login:
+        % if allow_public_account_creation:
+          % if should_redirect_to_authn_mfe:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
+            </div>
+          % else:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+          % endif
+        % endif
+        % if should_redirect_to_authn_mfe:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % else:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % endif
+      % endif
+    </div>
+  </div>
+</nav>

--- a/tutorindigo/templates/ncatech/lms/templates/header/navbar-authenticated.html
+++ b/tutorindigo/templates/ncatech/lms/templates/header/navbar-authenticated.html
@@ -1,0 +1,64 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+  show_explore_courses = False # configuration_helpers.get_value('COURSES_ARE_BROWSABLE', settings.FEATURES.get('COURSES_ARE_BROWSABLE'))
+  self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+
+  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+  doc_link = get_online_help_info(online_help_token)['doc_url']
+
+  if online_help_token == "instructor":
+    help_link = doc_link
+  elif support_link:
+    help_link = support_link
+  else:
+    help_link = doc_link
+%>
+
+<div class="nav-links">
+  <div class="main">
+    % if show_dashboard_tabs:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+             ${_("Courses")}
+        </a>
+      </div>
+      % if show_program_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
+             aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
+             ${_("Programs")}
+          </a>
+        </div>
+      % endif
+    % endif
+    % if show_explore_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
+             aria-current="${'page' if '/courses' in request.path else 'false'}">
+             ${_('Discover New')}
+          </a>
+      </div>
+    % endif
+  </div>
+  <div class="secondary">
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
+      </div>
+    % endif
+    <%include file="user_dropdown.html"/>
+  </div>
+</div>

--- a/tutorindigo/templates/ncatech/lms/templates/header/navbar-not-authenticated.html
+++ b/tutorindigo/templates/ncatech/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,74 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+
+<%!
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+
+from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
+%>
+<nav class="nav-links" aria-label=${_("Supplemental Links")}>
+  <div class="main">
+  % if False and mktg_site_enabled:
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+    </div>
+    % if courses_are_browsable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      </div>
+    % endif
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('SCHOOLS')}">${_("Schools")}</a>
+    </div>
+  % endif
+  % if allows_login:
+    % if False and can_discover_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="/courses">${_('Explore courses')}</a>
+      </div>
+    %endif
+  % endif
+  </div>
+  <div class="secondary">
+    <div>
+      % if allows_login:
+        % if allow_public_account_creation:
+          % if should_redirect_to_authn_mfe:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
+            </div>
+          % else:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+          % endif
+        % endif
+        % if should_redirect_to_authn_mfe:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % else:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % endif
+      % endif
+    </div>
+  </div>
+</nav>

--- a/tutorindigo/templates/photonics/lms/templates/header/navbar-authenticated.html
+++ b/tutorindigo/templates/photonics/lms/templates/header/navbar-authenticated.html
@@ -1,0 +1,64 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+  show_explore_courses = False # configuration_helpers.get_value('COURSES_ARE_BROWSABLE', settings.FEATURES.get('COURSES_ARE_BROWSABLE'))
+  self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+
+  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+  doc_link = get_online_help_info(online_help_token)['doc_url']
+
+  if online_help_token == "instructor":
+    help_link = doc_link
+  elif support_link:
+    help_link = support_link
+  else:
+    help_link = doc_link
+%>
+
+<div class="nav-links">
+  <div class="main">
+    % if show_dashboard_tabs:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+             ${_("Courses")}
+        </a>
+      </div>
+      % if show_program_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
+             aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
+             ${_("Programs")}
+          </a>
+        </div>
+      % endif
+    % endif
+    % if show_explore_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
+             aria-current="${'page' if '/courses' in request.path else 'false'}">
+             ${_('Discover New')}
+          </a>
+      </div>
+    % endif
+  </div>
+  <div class="secondary">
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
+      </div>
+    % endif
+    <%include file="user_dropdown.html"/>
+  </div>
+</div>

--- a/tutorindigo/templates/photonics/lms/templates/header/navbar-not-authenticated.html
+++ b/tutorindigo/templates/photonics/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,74 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+
+<%!
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+
+from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
+%>
+<nav class="nav-links" aria-label=${_("Supplemental Links")}>
+  <div class="main">
+  % if False and mktg_site_enabled:
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+    </div>
+    % if courses_are_browsable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      </div>
+    % endif
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('SCHOOLS')}">${_("Schools")}</a>
+    </div>
+  % endif
+  % if allows_login:
+    % if False and can_discover_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="/courses">${_('Explore courses')}</a>
+      </div>
+    %endif
+  % endif
+  </div>
+  <div class="secondary">
+    <div>
+      % if allows_login:
+        % if allow_public_account_creation:
+          % if should_redirect_to_authn_mfe:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
+            </div>
+          % else:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+          % endif
+        % endif
+        % if should_redirect_to_authn_mfe:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % else:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % endif
+      % endif
+    </div>
+  </div>
+</nav>

--- a/tutorindigo/templates/recitexr/lms/templates/header/navbar-authenticated.html
+++ b/tutorindigo/templates/recitexr/lms/templates/header/navbar-authenticated.html
@@ -1,0 +1,64 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+  show_explore_courses = False # configuration_helpers.get_value('COURSES_ARE_BROWSABLE', settings.FEATURES.get('COURSES_ARE_BROWSABLE'))
+  self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+
+  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+  doc_link = get_online_help_info(online_help_token)['doc_url']
+
+  if online_help_token == "instructor":
+    help_link = doc_link
+  elif support_link:
+    help_link = support_link
+  else:
+    help_link = doc_link
+%>
+
+<div class="nav-links">
+  <div class="main">
+    % if show_dashboard_tabs:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+             ${_("Courses")}
+        </a>
+      </div>
+      % if show_program_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
+             aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
+             ${_("Programs")}
+          </a>
+        </div>
+      % endif
+    % endif
+    % if show_explore_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
+             aria-current="${'page' if '/courses' in request.path else 'false'}">
+             ${_('Discover New')}
+          </a>
+      </div>
+    % endif
+  </div>
+  <div class="secondary">
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
+      </div>
+    % endif
+    <%include file="user_dropdown.html"/>
+  </div>
+</div>

--- a/tutorindigo/templates/recitexr/lms/templates/header/navbar-not-authenticated.html
+++ b/tutorindigo/templates/recitexr/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,74 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+
+<%!
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+
+from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
+%>
+<nav class="nav-links" aria-label=${_("Supplemental Links")}>
+  <div class="main">
+  % if False and mktg_site_enabled:
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+    </div>
+    % if courses_are_browsable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      </div>
+    % endif
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('SCHOOLS')}">${_("Schools")}</a>
+    </div>
+  % endif
+  % if allows_login:
+    % if False and can_discover_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="/courses">${_('Explore courses')}</a>
+      </div>
+    %endif
+  % endif
+  </div>
+  <div class="secondary">
+    <div>
+      % if allows_login:
+        % if allow_public_account_creation:
+          % if should_redirect_to_authn_mfe:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
+            </div>
+          % else:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+          % endif
+        % endif
+        % if should_redirect_to_authn_mfe:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % else:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % endif
+      % endif
+    </div>
+  </div>
+</nav>

--- a/tutorindigo/templates/recitexr/tasks/lms/init
+++ b/tutorindigo/templates/recitexr/tasks/lms/init
@@ -23,7 +23,7 @@ do
     site-configuration set --domain=$domain ENABLE_COMBINED_LOGIN_REGISTRATION true
     site-configuration set --domain=$domain ENABLE_COURSE_DISCOVERY false
     site-configuration set --domain=$domain ENABLE_DASHBOARD_SEARCH true
-    site-configuration set --domain=$domain ENABLE_MKTG_SITE true    
+    site-configuration set --domain=$domain ENABLE_MKTG_SITE false    
     site-configuration set --domain=$domain ENABLE_PAID_COURSE_REGISTRATION true
     site-configuration set --domain=$domain ENABLE_PROFILE_MICROFRONTEND true
     site-configuration set --domain=$domain ENABLE_SHOPPING_CART true

--- a/tutorindigo/templates/revved-gvltec/lms/templates/header/navbar-authenticated.html
+++ b/tutorindigo/templates/revved-gvltec/lms/templates/header/navbar-authenticated.html
@@ -1,0 +1,64 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+  show_explore_courses = False # configuration_helpers.get_value('COURSES_ARE_BROWSABLE', settings.FEATURES.get('COURSES_ARE_BROWSABLE'))
+  self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+
+  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+  doc_link = get_online_help_info(online_help_token)['doc_url']
+
+  if online_help_token == "instructor":
+    help_link = doc_link
+  elif support_link:
+    help_link = support_link
+  else:
+    help_link = doc_link
+%>
+
+<div class="nav-links">
+  <div class="main">
+    % if show_dashboard_tabs:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+             ${_("Courses")}
+        </a>
+      </div>
+      % if show_program_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
+             aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
+             ${_("Programs")}
+          </a>
+        </div>
+      % endif
+    % endif
+    % if show_explore_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
+             aria-current="${'page' if '/courses' in request.path else 'false'}">
+             ${_('Discover New')}
+          </a>
+      </div>
+    % endif
+  </div>
+  <div class="secondary">
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
+      </div>
+    % endif
+    <%include file="user_dropdown.html"/>
+  </div>
+</div>

--- a/tutorindigo/templates/revved-gvltec/lms/templates/header/navbar-not-authenticated.html
+++ b/tutorindigo/templates/revved-gvltec/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,74 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+
+<%!
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+
+from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
+%>
+<nav class="nav-links" aria-label=${_("Supplemental Links")}>
+  <div class="main">
+  % if False and mktg_site_enabled:
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+    </div>
+    % if courses_are_browsable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      </div>
+    % endif
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('SCHOOLS')}">${_("Schools")}</a>
+    </div>
+  % endif
+  % if allows_login:
+    % if False and can_discover_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="/courses">${_('Explore courses')}</a>
+      </div>
+    %endif
+  % endif
+  </div>
+  <div class="secondary">
+    <div>
+      % if allows_login:
+        % if allow_public_account_creation:
+          % if should_redirect_to_authn_mfe:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
+            </div>
+          % else:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+          % endif
+        % endif
+        % if should_redirect_to_authn_mfe:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % else:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % endif
+      % endif
+    </div>
+  </div>
+</nav>

--- a/tutorindigo/templates/revved-sccsc/lms/templates/header/navbar-authenticated.html
+++ b/tutorindigo/templates/revved-sccsc/lms/templates/header/navbar-authenticated.html
@@ -1,0 +1,64 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+  show_explore_courses = False # configuration_helpers.get_value('COURSES_ARE_BROWSABLE', settings.FEATURES.get('COURSES_ARE_BROWSABLE'))
+  self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+
+  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+  doc_link = get_online_help_info(online_help_token)['doc_url']
+
+  if online_help_token == "instructor":
+    help_link = doc_link
+  elif support_link:
+    help_link = support_link
+  else:
+    help_link = doc_link
+%>
+
+<div class="nav-links">
+  <div class="main">
+    % if show_dashboard_tabs:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+             ${_("Courses")}
+        </a>
+      </div>
+      % if show_program_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
+             aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
+             ${_("Programs")}
+          </a>
+        </div>
+      % endif
+    % endif
+    % if show_explore_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
+             aria-current="${'page' if '/courses' in request.path else 'false'}">
+             ${_('Discover New')}
+          </a>
+      </div>
+    % endif
+  </div>
+  <div class="secondary">
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
+      </div>
+    % endif
+    <%include file="user_dropdown.html"/>
+  </div>
+</div>

--- a/tutorindigo/templates/revved-sccsc/lms/templates/header/navbar-not-authenticated.html
+++ b/tutorindigo/templates/revved-sccsc/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,74 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+
+<%!
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+
+from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
+%>
+<nav class="nav-links" aria-label=${_("Supplemental Links")}>
+  <div class="main">
+  % if False and mktg_site_enabled:
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+    </div>
+    % if courses_are_browsable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      </div>
+    % endif
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('SCHOOLS')}">${_("Schools")}</a>
+    </div>
+  % endif
+  % if allows_login:
+    % if False and can_discover_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="/courses">${_('Explore courses')}</a>
+      </div>
+    %endif
+  % endif
+  </div>
+  <div class="secondary">
+    <div>
+      % if allows_login:
+        % if allow_public_account_creation:
+          % if should_redirect_to_authn_mfe:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
+            </div>
+          % else:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+          % endif
+        % endif
+        % if should_redirect_to_authn_mfe:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % else:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % endif
+      % endif
+    </div>
+  </div>
+</nav>

--- a/tutorindigo/templates/revved-tridenttech/lms/templates/header/navbar-authenticated.html
+++ b/tutorindigo/templates/revved-tridenttech/lms/templates/header/navbar-authenticated.html
@@ -1,0 +1,64 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+  show_explore_courses = False # configuration_helpers.get_value('COURSES_ARE_BROWSABLE', settings.FEATURES.get('COURSES_ARE_BROWSABLE'))
+  self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+
+  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+  doc_link = get_online_help_info(online_help_token)['doc_url']
+
+  if online_help_token == "instructor":
+    help_link = doc_link
+  elif support_link:
+    help_link = support_link
+  else:
+    help_link = doc_link
+%>
+
+<div class="nav-links">
+  <div class="main">
+    % if show_dashboard_tabs:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+             ${_("Courses")}
+        </a>
+      </div>
+      % if show_program_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
+             aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
+             ${_("Programs")}
+          </a>
+        </div>
+      % endif
+    % endif
+    % if show_explore_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
+             aria-current="${'page' if '/courses' in request.path else 'false'}">
+             ${_('Discover New')}
+          </a>
+      </div>
+    % endif
+  </div>
+  <div class="secondary">
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
+      </div>
+    % endif
+    <%include file="user_dropdown.html"/>
+  </div>
+</div>

--- a/tutorindigo/templates/revved-tridenttech/lms/templates/header/navbar-not-authenticated.html
+++ b/tutorindigo/templates/revved-tridenttech/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,74 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+
+<%!
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+
+from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
+%>
+<nav class="nav-links" aria-label=${_("Supplemental Links")}>
+  <div class="main">
+  % if False and mktg_site_enabled:
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+    </div>
+    % if courses_are_browsable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      </div>
+    % endif
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('SCHOOLS')}">${_("Schools")}</a>
+    </div>
+  % endif
+  % if allows_login:
+    % if False and can_discover_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="/courses">${_('Explore courses')}</a>
+      </div>
+    %endif
+  % endif
+  </div>
+  <div class="secondary">
+    <div>
+      % if allows_login:
+        % if allow_public_account_creation:
+          % if should_redirect_to_authn_mfe:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
+            </div>
+          % else:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+          % endif
+        % endif
+        % if should_redirect_to_authn_mfe:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % else:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % endif
+      % endif
+    </div>
+  </div>
+</nav>

--- a/tutorindigo/templates/revved/lms/templates/header/navbar-authenticated.html
+++ b/tutorindigo/templates/revved/lms/templates/header/navbar-authenticated.html
@@ -1,0 +1,64 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+  show_explore_courses = False # configuration_helpers.get_value('COURSES_ARE_BROWSABLE', settings.FEATURES.get('COURSES_ARE_BROWSABLE'))
+  self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+
+  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+  doc_link = get_online_help_info(online_help_token)['doc_url']
+
+  if online_help_token == "instructor":
+    help_link = doc_link
+  elif support_link:
+    help_link = support_link
+  else:
+    help_link = doc_link
+%>
+
+<div class="nav-links">
+  <div class="main">
+    % if show_dashboard_tabs:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+             ${_("Courses")}
+        </a>
+      </div>
+      % if show_program_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
+             aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
+             ${_("Programs")}
+          </a>
+        </div>
+      % endif
+    % endif
+    % if show_explore_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
+             aria-current="${'page' if '/courses' in request.path else 'false'}">
+             ${_('Discover New')}
+          </a>
+      </div>
+    % endif
+  </div>
+  <div class="secondary">
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
+      </div>
+    % endif
+    <%include file="user_dropdown.html"/>
+  </div>
+</div>

--- a/tutorindigo/templates/revved/lms/templates/header/navbar-not-authenticated.html
+++ b/tutorindigo/templates/revved/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,74 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+
+<%!
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+
+from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
+%>
+<nav class="nav-links" aria-label=${_("Supplemental Links")}>
+  <div class="main">
+  % if False and mktg_site_enabled:
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+    </div>
+    % if courses_are_browsable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      </div>
+    % endif
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('SCHOOLS')}">${_("Schools")}</a>
+    </div>
+  % endif
+  % if allows_login:
+    % if False and can_discover_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="/courses">${_('Explore courses')}</a>
+      </div>
+    %endif
+  % endif
+  </div>
+  <div class="secondary">
+    <div>
+      % if allows_login:
+        % if allow_public_account_creation:
+          % if should_redirect_to_authn_mfe:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
+            </div>
+          % else:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+          % endif
+        % endif
+        % if should_redirect_to_authn_mfe:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % else:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % endif
+      % endif
+    </div>
+  </div>
+</nav>

--- a/tutorindigo/templates/spartanburg/lms/templates/header/navbar-authenticated.html
+++ b/tutorindigo/templates/spartanburg/lms/templates/header/navbar-authenticated.html
@@ -1,0 +1,64 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+  show_explore_courses = False # configuration_helpers.get_value('COURSES_ARE_BROWSABLE', settings.FEATURES.get('COURSES_ARE_BROWSABLE'))
+  self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+
+  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+  doc_link = get_online_help_info(online_help_token)['doc_url']
+
+  if online_help_token == "instructor":
+    help_link = doc_link
+  elif support_link:
+    help_link = support_link
+  else:
+    help_link = doc_link
+%>
+
+<div class="nav-links">
+  <div class="main">
+    % if show_dashboard_tabs:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+             ${_("Courses")}
+        </a>
+      </div>
+      % if show_program_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
+             aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
+             ${_("Programs")}
+          </a>
+        </div>
+      % endif
+    % endif
+    % if show_explore_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
+             aria-current="${'page' if '/courses' in request.path else 'false'}">
+             ${_('Discover New')}
+          </a>
+      </div>
+    % endif
+  </div>
+  <div class="secondary">
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
+      </div>
+    % endif
+    <%include file="user_dropdown.html"/>
+  </div>
+</div>

--- a/tutorindigo/templates/spartanburg/lms/templates/header/navbar-not-authenticated.html
+++ b/tutorindigo/templates/spartanburg/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,74 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+
+<%!
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+
+from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
+%>
+<nav class="nav-links" aria-label=${_("Supplemental Links")}>
+  <div class="main">
+  % if False and mktg_site_enabled:
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+    </div>
+    % if courses_are_browsable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      </div>
+    % endif
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('SCHOOLS')}">${_("Schools")}</a>
+    </div>
+  % endif
+  % if allows_login:
+    % if False and can_discover_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="/courses">${_('Explore courses')}</a>
+      </div>
+    %endif
+  % endif
+  </div>
+  <div class="secondary">
+    <div>
+      % if allows_login:
+        % if allow_public_account_creation:
+          % if should_redirect_to_authn_mfe:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
+            </div>
+          % else:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+          % endif
+        % endif
+        % if should_redirect_to_authn_mfe:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % else:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % endif
+      % endif
+    </div>
+  </div>
+</nav>

--- a/tutorindigo/templates/thin-school/lms/templates/header/navbar-authenticated.html
+++ b/tutorindigo/templates/thin-school/lms/templates/header/navbar-authenticated.html
@@ -1,0 +1,64 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+  show_explore_courses = False # configuration_helpers.get_value('COURSES_ARE_BROWSABLE', settings.FEATURES.get('COURSES_ARE_BROWSABLE'))
+  self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+
+  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+  doc_link = get_online_help_info(online_help_token)['doc_url']
+
+  if online_help_token == "instructor":
+    help_link = doc_link
+  elif support_link:
+    help_link = support_link
+  else:
+    help_link = doc_link
+%>
+
+<div class="nav-links">
+  <div class="main">
+    % if show_dashboard_tabs:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+             ${_("Courses")}
+        </a>
+      </div>
+      % if show_program_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
+             aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
+             ${_("Programs")}
+          </a>
+        </div>
+      % endif
+    % endif
+    % if show_explore_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
+             aria-current="${'page' if '/courses' in request.path else 'false'}">
+             ${_('Discover New')}
+          </a>
+      </div>
+    % endif
+  </div>
+  <div class="secondary">
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
+      </div>
+    % endif
+    <%include file="user_dropdown.html"/>
+  </div>
+</div>

--- a/tutorindigo/templates/thin-school/lms/templates/header/navbar-not-authenticated.html
+++ b/tutorindigo/templates/thin-school/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,74 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+
+<%!
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+
+from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
+%>
+<nav class="nav-links" aria-label=${_("Supplemental Links")}>
+  <div class="main">
+  % if False and mktg_site_enabled:
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+    </div>
+    % if courses_are_browsable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      </div>
+    % endif
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('SCHOOLS')}">${_("Schools")}</a>
+    </div>
+  % endif
+  % if allows_login:
+    % if False and can_discover_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="/courses">${_('Explore courses')}</a>
+      </div>
+    %endif
+  % endif
+  </div>
+  <div class="secondary">
+    <div>
+      % if allows_login:
+        % if allow_public_account_creation:
+          % if should_redirect_to_authn_mfe:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
+            </div>
+          % else:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+          % endif
+        % endif
+        % if should_redirect_to_authn_mfe:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % else:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % endif
+      % endif
+    </div>
+  </div>
+</nav>

--- a/tutorindigo/templates/trustworks-cymanii/lms/templates/header/navbar-authenticated.html
+++ b/tutorindigo/templates/trustworks-cymanii/lms/templates/header/navbar-authenticated.html
@@ -1,0 +1,64 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+  show_explore_courses = False # configuration_helpers.get_value('COURSES_ARE_BROWSABLE', settings.FEATURES.get('COURSES_ARE_BROWSABLE'))
+  self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+
+  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+  doc_link = get_online_help_info(online_help_token)['doc_url']
+
+  if online_help_token == "instructor":
+    help_link = doc_link
+  elif support_link:
+    help_link = support_link
+  else:
+    help_link = doc_link
+%>
+
+<div class="nav-links">
+  <div class="main">
+    % if show_dashboard_tabs:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+             ${_("Courses")}
+        </a>
+      </div>
+      % if show_program_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
+             aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
+             ${_("Programs")}
+          </a>
+        </div>
+      % endif
+    % endif
+    % if show_explore_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
+             aria-current="${'page' if '/courses' in request.path else 'false'}">
+             ${_('Discover New')}
+          </a>
+      </div>
+    % endif
+  </div>
+  <div class="secondary">
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
+      </div>
+    % endif
+    <%include file="user_dropdown.html"/>
+  </div>
+</div>

--- a/tutorindigo/templates/trustworks-cymanii/lms/templates/header/navbar-not-authenticated.html
+++ b/tutorindigo/templates/trustworks-cymanii/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,74 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+
+<%!
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+
+from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
+%>
+<nav class="nav-links" aria-label=${_("Supplemental Links")}>
+  <div class="main">
+  % if False and mktg_site_enabled:
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+    </div>
+    % if courses_are_browsable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      </div>
+    % endif
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('SCHOOLS')}">${_("Schools")}</a>
+    </div>
+  % endif
+  % if allows_login:
+    % if False and can_discover_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="/courses">${_('Explore courses')}</a>
+      </div>
+    %endif
+  % endif
+  </div>
+  <div class="secondary">
+    <div>
+      % if allows_login:
+        % if allow_public_account_creation:
+          % if should_redirect_to_authn_mfe:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
+            </div>
+          % else:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+          % endif
+        % endif
+        % if should_redirect_to_authn_mfe:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % else:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % endif
+      % endif
+    </div>
+  </div>
+</nav>

--- a/tutorindigo/templates/water-drops/lms/templates/header/navbar-authenticated.html
+++ b/tutorindigo/templates/water-drops/lms/templates/header/navbar-authenticated.html
@@ -1,0 +1,64 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+%>
+
+<%
+  show_explore_courses = False # configuration_helpers.get_value('COURSES_ARE_BROWSABLE', settings.FEATURES.get('COURSES_ARE_BROWSABLE'))
+  self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+
+  support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+  doc_link = get_online_help_info(online_help_token)['doc_url']
+
+  if online_help_token == "instructor":
+    help_link = doc_link
+  elif support_link:
+    help_link = support_link
+  else:
+    help_link = doc_link
+%>
+
+<div class="nav-links">
+  <div class="main">
+    % if show_dashboard_tabs:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+             ${_("Courses")}
+        </a>
+      </div>
+      % if show_program_listing:
+        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
+             aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
+             ${_("Programs")}
+          </a>
+        </div>
+      % endif
+    % endif
+    % if show_explore_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
+             aria-current="${'page' if '/courses' in request.path else 'false'}">
+             ${_('Discover New')}
+          </a>
+      </div>
+    % endif
+  </div>
+  <div class="secondary">
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
+      </div>
+    % endif
+    <%include file="user_dropdown.html"/>
+  </div>
+</div>

--- a/tutorindigo/templates/water-drops/lms/templates/header/navbar-not-authenticated.html
+++ b/tutorindigo/templates/water-drops/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,74 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+
+<%!
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+
+from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
+%>
+<nav class="nav-links" aria-label=${_("Supplemental Links")}>
+  <div class="main">
+  % if False and mktg_site_enabled:
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+    </div>
+    % if courses_are_browsable:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      </div>
+    % endif
+    <div class="mobile-nav-item hidden-mobile nav-item">
+      <a href="${marketing_link('SCHOOLS')}">${_("Schools")}</a>
+    </div>
+  % endif
+  % if allows_login:
+    % if False and can_discover_courses:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a href="/courses">${_('Explore courses')}</a>
+      </div>
+    %endif
+  % endif
+  </div>
+  <div class="secondary">
+    <div>
+      % if allows_login:
+        % if allow_public_account_creation:
+          % if should_redirect_to_authn_mfe:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
+            </div>
+          % else:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+          % endif
+        % endif
+        % if should_redirect_to_authn_mfe:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="${settings.AUTHN_MICROFRONTEND_URL}/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % else:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % endif
+      % endif
+    </div>
+  </div>
+</nav>


### PR DESCRIPTION
Kapil brought this to my attention that we'd like to remove the LMS primary navigation links that are unused.

Reference 
https://educateworkforce.zendesk.com/agent/tickets/1000

For the `navigation-authenticated.hml` template I couldn't get the SiteConfiguration to work with the COURSE_ARE_BROWSABLE variable. I tried both `False` and `false` values.