### PR TITLE
Make sure the 'PLATFORM_NAME' says RECITEXR instead of REVVED.

### DIFF
--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -282,7 +282,7 @@ config = {
                 "MKG_ROOT_URL": f"recitexr.{MKG_HOST}",
             },
             "common": {
-                "PLATFORM_NAME": "{{ PLATFORM_NAME }} - REVVED",
+                "PLATFORM_NAME": "{{ PLATFORM_NAME }} - RECITEXR",
                 "PRIMARY_COLOR": EDUCATEWORKFORCE_BLUE,
                 "FOOTER_NAV_LINKS": [
                     {"title": "Contact", "url": "/contact"},


### PR DESCRIPTION
Kapil found this issue on the https://recitexr.courses.educateworkforce.com/contact page. Because this `PLATFORM_NAME` may be used in more place, I'm going to rebuild the `openedx` images with this change.