### PR TITLE
Limit Choose Aerospace `REGISTRATION_EXTRA_FIELDS`.

### DIFF
--- a/tutorindigo/templates/choose-aerospace/tasks/lms/init
+++ b/tutorindigo/templates/choose-aerospace/tasks/lms/init
@@ -121,6 +121,24 @@ do
     " --json-argument
     site-configuration set --domain=$domain PLATFORM_NAME "{{ CHOOSE_AEROSPACE_PLATFORM_NAME }}"
     site-configuration set --domain=$domain PROFILE_MICROFRONTEND_URL "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ CHOOSE_AEROSPACE_MFE_HOST }}/profile/u/"
+    site-configuration set --domain=$domain REGISTRATION_EXTRA_FIELDS \
+    "
+    {
+        \"country\": \"required\",
+        \"employment_status\": \"hidden\",
+        \"enrolled_in_school\": \"hidden\",
+        \"enrolled_in_school_type\": \"hidden\",
+        \"ethnicity\": \"hidden\",
+        \"gender\": \"hidden\",
+        \"goals\": \"hidden\",
+        \"honor_code\": \"hidden\",
+        \"level_of_education\": \"hidden\",
+        \"local_community_living\": \"hidden\",
+        \"terms_of_service\": \"required\",
+        \"year_of_birth\": \"hidden\",
+        \"zipcode\": \"required\"
+    }
+    " --json-argument
     site-configuration set --domain=$domain RESTRICT_ENROLL_BY_REG_METHOD true
 
     {% if CHOOSE_AEROSPACE_SESSION_COOKIE_DOMAIN %}


### PR DESCRIPTION
In an effort to evaluate how students are doing, CA has decided to remove most of the existing demographic fields and we've instead moved them into a Qualtrics survey for both pre/post-program for the Aviation Mechanic General.
