### PR TITLE
Added `Cape Fear Community College` to the CORS Whitelist.

### DIFF
--- a/tutorindigo/patches/openedx-lms-production-settings
+++ b/tutorindigo/patches/openedx-lms-production-settings
@@ -9,6 +9,10 @@ if "https://idp.app.clemson.edu" not in CORS_ORIGIN_WHITELIST:
 
 #################### External LTI Consumer Settings #######################
 
+# Cape Fear Community College
+if "https://cfcc.instructure.com" not in CORS_ORIGIN_WHITELIST:
+    CORS_ORIGIN_WHITELIST.append("https://cfcc.instructure.com")
+
 # Clemson Canvas
 if "https://clemson.instructure.com" not in CORS_ORIGIN_WHITELIST:
     CORS_ORIGIN_WHITELIST.append("https://clemson.instructure.com")


### PR DESCRIPTION
Needed to make sure to whitelist the Cape Fear Community College Canvas LMS URL to get access to the LTI content on EducateWorkforce.